### PR TITLE
remove 0x before searching for key file

### DIFF
--- a/index.js
+++ b/index.js
@@ -560,7 +560,7 @@ module.exports = {
      * @return {Object} Keystore data file's contents.
      */
     importFromFile: function (address, datadir, cb) {
-
+        address = address.replace('0x', '');
         function findKeyfile(address, files) {
             var filepath = null;
             for (var i = 0, len = files.length; i < len; ++i) {


### PR DESCRIPTION
Hi. When using web3 eth.accounts returns a string with the 0x prefix. But the prefix is not in the key file name produced by geth so keythereum doesn't find it.